### PR TITLE
Solve Symfony 3.1 deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ matrix:
   allow_failures:
     - php: hhvm
 before_script:
-  - composer config -g github-oauth.github.com $GITHUB_COMPOSER_AUTH
   - composer install --no-interaction --prefer-dist
 script:
   - vendor/bin/phpunit --coverage-clover=coveralls.clover

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,9 @@ matrix:
   allow_failures:
     - php: hhvm
 before_script:
-  - php -dmemory_limit=-1 $(which composer) install --no-interaction --prefer-dist
+  - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  - php -i | grep memory_limit
+  - composer install --no-interaction --prefer-dist
 script:
   - vendor/bin/phpunit --coverage-clover=coveralls.clover
   - vendor/bin/phpcs -p --standard=PSR2 --ignore=vendor/,Tests/app/ ./

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
   allow_failures:
     - php: hhvm
 before_script:
-  - composer install --no-interaction --prefer-dist
+  - php -dmemory_limit=-1 $(which composer) install --no-interaction --prefer-dist
 script:
   - vendor/bin/phpunit --coverage-clover=coveralls.clover
   - vendor/bin/phpcs -p --standard=PSR2 --ignore=vendor/,Tests/app/ ./

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -7,10 +7,10 @@ parameters:
 
 services:
     ongr_cookie.injector:
-        class: %ongr_cookie.injector.class%
+        class: "%ongr_cookie.injector.class%"
 
     ongr_cookie.listener:
-        class: %ongr_cookie.listener.class%
+        class: "%ongr_cookie.listener.class%"
         calls:
             - [ setCookieInjector, [ "@ongr_cookie.injector" ] ]
         tags:


### PR DESCRIPTION
>Not quoting the scalar "%ongr_cookie.injector.class%" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0 in "/var/www/skycop-core/vendor/ongr/cookies-bundle/DependencyInjection/../Resources/config/services.yml" on line 10.

>Not quoting the scalar "%ongr_cookie.listener.class%" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0 in "/var/www/skycop-core/vendor/ongr/cookies-bundle/DependencyInjection/../Resources/config/services.yml" on line 13.